### PR TITLE
Added image used as test for imagemeasure notebook

### DIFF
--- a/notebooks/imagemeasure.ipynb
+++ b/notebooks/imagemeasure.ipynb
@@ -2,14 +2,28 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[162, 60]]\n",
+      "[[128, 787]]\n",
+      "[586.60245879]\n"
+     ]
+    }
+   ],
    "source": [
     "import cv2\n",
     "import numpy as np\n",
     "import math\n",
     "from scipy.spatial.distance import cdist\n",
+    "\n",
+    "# This program opens in a new window the image you want and with the left click and right click you \n",
+    "# take two points in the image and draws a line conecting each one and prints its length on shell (it\n",
+    "# measures in pixels but I added a transformation to obtain a real distance)\n",
     "\n",
     "pointsl=[]\n",
     "pointsr=[]\n",
@@ -58,11 +72,35 @@
     "print(pointsr)\n",
     "print(np.diagonal(cdist(pointsl,pointsr,'euclidean'))*0.806)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "interpreter": {
+   "hash": "a818ab11ab10ac998ea662494f7172710092879c7c5649f6c41b582d973b9277"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9.7 64-bit ('testing': conda)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   },
   "orig_nbformat": 4
  },


### PR DESCRIPTION
User specifies the image to analize, with left click and right click defines pairs of points and the program draws a line connecting them and prints the length of each line (shown in order of apperance) in shell
I added a unit transformation corresponding to my image to obtain the real distance in the photo (without it the length and coordinates are shown in pixels)